### PR TITLE
Исправить Docker Compose и настройку Composer в материалах первого урока

### DIFF
--- a/practice/lesson-01/Makefile
+++ b/practice/lesson-01/Makefile
@@ -1,4 +1,4 @@
-COMPOSE=docker-compose
+COMPOSE=docker compose
 PHP=$(COMPOSE) exec php
 CONSOLE=$(PHP) bin/console
 COMPOSER=$(PHP) composer

--- a/practice/lesson-01/README.md
+++ b/practice/lesson-01/README.md
@@ -48,14 +48,14 @@ $ sudo cat /etc/hosts
 
 Запускаем контейнер
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 #### Создание проекта
 
 Создаем проект StudyOn
 ```bash
-docker-compose exec php composer create-project symfony/skeleton study-on
+docker compose exec php composer create-project symfony/skeleton study-on
 ```
 Проект создается в поддиректории study-on
 Перемещаем файлы на уровень выше (в текущую директорию)
@@ -71,9 +71,8 @@ echo 'NGINX_PORT=81' >> .env
 ```
 
 Доустанавливаем `symfony/webapp-pack`
-```
-cd study-on
-docker-compose exec php composer require symfony/webapp-pack
+```bash
+docker compose exec php composer require symfony/webapp-pack
 ```
 
 На вопрос "Do you want to include Docker configuration from recipes?" отвечаем **No**, у нас в проекте будут свои конфиги Docker.
@@ -109,14 +108,14 @@ cd ~/sf-lessons/study-on.billing
 Используем только symfony/skeleton. Отдельно доустанавливаем phpunit
 
 ```bash
-docker-compose exec php composer create-project symfony/skeleton study-on.billing
+docker compose exec php composer create-project symfony/skeleton study-on.billing
 
 cp -a study-on.billing/. .
 rm -r study-on.billing/
 
 echo 'NGINX_PORT=82' >> .env
 
-docker-compose exec php composer require symfony/phpunit-bridge
+docker compose exec php composer require symfony/phpunit-bridge
 
 ```
 
@@ -130,33 +129,33 @@ git remote add origin https://github.com/sfuser/study-on.billing.git
 
 ## Работа с Docker Compose
 
-Ниже показаны примеры типовых операций с docker-compose. Все операции выполняются в папке, где расположен `docker-compose.yml`.
+Ниже показаны примеры типовых операций с Docker Compose. Все операции выполняются в папке, где расположен `docker-compose.yml`.
 
 Запуск сборки
 ```bash
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 Остановка работы сборки
 ```bash
-$ docker-compose down
+$ docker compose down
 ```
 
 Запуск команды внутри запущенного контейнера
 ```bash
-$ docker-compose exec php bin/console list
+$ docker compose exec php bin/console list
 ```
 
 ## Работа с make
 
 Пояснения и синтаксис запуска make-команд из [Makefile](Makefile).
 
-Запустить docker-compose
+Запустить Docker Compose
 ```bash
 $ make up
 ```
 
-Остановить docker-compose
+Остановить Docker Compose
 ```bash
 $ make down
 ```

--- a/practice/lesson-01/docker-compose.yml
+++ b/practice/lesson-01/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 volumes:
   postgres: ~
 services:
@@ -28,8 +27,10 @@ services:
     user: ${UID:-1000}:${GID:-1000}
     volumes:
       - ${PWD}:/app
-      - ${HOME}/.composer:/.composer
     environment:
+      - HOME=/tmp
+      - COMPOSER_HOME=/tmp/.composer
+      - COMPOSER_CACHE_DIR=/tmp/.composer/cache
       - COMPOSER_ALLOW_SUPERUSER=1
     links:
       - postgres

--- a/practice/lesson-01/docker/images/php/Dockerfile
+++ b/practice/lesson-01/docker/images/php/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
         curl \
         wget \
         git \
+        unzip \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
@@ -19,7 +20,8 @@ RUN apt-get update && apt-get install -y \
         openssl \
     && docker-php-ext-install -j$(nproc) intl bcmath soap pgsql pdo_pgsql zip \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd
+    && docker-php-ext-install -j$(nproc) gd \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/practice/lesson-01/phpcs.md
+++ b/practice/lesson-01/phpcs.md
@@ -3,7 +3,7 @@
 Установите [codesniffer](https://github.com/squizlabs/PHP_CodeSniffer) в директории проекта
 
 ```
-docker-compose exec php composer require --dev squizlabs/php_codesniffer
+docker compose exec php composer require --dev squizlabs/php_codesniffer
 ```
 
 Скопируйте создавшийся файл phpcs.xml.dist в phpcs.xml, он содержит настройки phpcs, в частности, указание стандарта [PSR-2](https://www.php-fig.org/psr/psr-2/)


### PR DESCRIPTION
- заменить устаревшие команды docker-compose на docker compose
- исправить шаги в README после переноса файлов Symfony-проекта
- убрать устаревший version из docker-compose.yml
- настроить Composer cache и добавить unzip в PHP-образ