### PR TITLE
Update lesson 03 frontend setup notes for Encore and modern Symfony

### DIFF
--- a/practice/lesson-03/README.md
+++ b/practice/lesson-03/README.md
@@ -2,50 +2,107 @@
 
 ## Установка Encore через контейнер
 
+Если проект был создан на современном Symfony skeleton, в нём уже может быть настроен `AssetMapper`/`importmap`.
+В этом задании фронтенд переводится на `Webpack Encore`, поэтому после его подключения проверьте, что в проекте не осталось двух конкурирующих способов подключения фронтенда одновременно.
+
 ```bash
-docker-compose run node yarn install
-docker-compose run node yarn add @symfony/webpack-encore --dev
+docker compose run --rm node yarn install
+docker compose run --rm php composer require symfony/webpack-encore-bundle
 ```
-Установите все необходимые зависимости
-Пример package.json для Symfony 7.2
+
+После установки `symfony/webpack-encore-bundle` Symfony recipe обычно уже создаёт:
+
+- `package.json`
+- `webpack.config.js`
+- `config/packages/webpack_encore.yaml`
+
+И может частично обновить `templates/base.html.twig`.
+
+Дальше состав зависимостей и точный вид `package.json` лучше собрать самостоятельно, исходя из того, какой стек вы реально используете в проекте.
+Ниже приведён минимальный ориентир для этого задания.
+
+Минимальный пример `package.json` для задания:
+
 ```
 {
   "devDependencies": {
     "@babel/core": "^7.17.0",
     "@babel/preset-env": "^7.16.0",
-    "@hotwired/stimulus": "^3.0.0",
-    "@hotwired/turbo": "^7.1.1 || ^8.0",
-    "@popperjs/core": "^2.11.7",
-    "@symfony/stimulus-bridge": "^3.2.0",
-    "@symfony/ux-turbo": "file:vendor/symfony/ux-turbo/assets",
-    "@symfony/webpack-encore": "^5.1.0",
-    "bootstrap": "^5.2.3",
-    "core-js": "^3.23.0",
-    "jquery": "^3.6.4",
+    "@popperjs/core": "^2.11.8",
+    "@symfony/webpack-encore": "^6.0.0",
+    "bootstrap": "^5.3.3",
+    "core-js": "^3.38.0",
     "regenerator-runtime": "^0.13.9",
-    "sass": "^1.62.0",
+    "sass": "^1.93.0",
     "sass-loader": "^16.0.5",
-    "webpack": "^5.74.0",
-    "webpack-cli": "^6.0.1"
+    "webpack": "^5.72",
+    "webpack-cli": "^6.0.0"
   },
-  "dependencies": {
-    "popper.js": "^1.16.1",
-    "stimulus": "^3.2.1"
+  "license": "UNLICENSED",
+  "private": true,
+  "scripts": {
+    "dev-server": "encore dev-server",
+    "dev": "encore dev",
+    "watch": "encore dev --watch",
+    "build": "encore production --progress"
   }
 }
+```
 
+Установить npm/yarn-зависимости:
+
+```bash
+docker compose run --rm node yarn install
 ```
 
 В репозитории есть пример [webpack.config.js](webpack.config.js)
+
+## Очистка от AssetMapper
+
+Если проект изначально был создан с `AssetMapper`, после перехода на Encore полезно удалить старые артефакты:
+
+- `symfony/asset-mapper` из `composer.json`
+- `config/packages/asset_mapper.yaml`
+- `importmap.php`
+- `importmap:install` из `composer.json` scripts
+
+Также обратите внимание на `templates/base.html.twig`: после переключения на Encore там не должно остаться старого способа подключения фронтенда.
 
 ## Make-команды для сборки фронтенда
 
 Добавьте для удобства в Makefile следующие команды:
 
 ```
+NODE=$(COMPOSE) run --rm node
+
 encore_dev:
-	@${COMPOSE} run node yarn encore dev
+	@${NODE} yarn dev
+
+encore_watch:
+	@${NODE} yarn watch
 
 encore_prod:
-	@${COMPOSE} run node yarn encore production
+	@${NODE} yarn build
 ```
+
+## Bootstrap и формы Symfony
+
+После подключения Bootstrap проверьте, как в проекте рендерятся Symfony-формы.
+Если вы хотите, чтобы `form_row()` сразу генерировал bootstrap-разметку, посмотрите в сторону bootstrap form theme из документации Symfony.
+
+## Кастомные страницы ошибок
+
+HTML-шаблоны ошибок в Symfony нужно размещать в:
+
+```text
+templates/bundles/TwigBundle/Exception/
+```
+
+Минимальный набор файлов для этого задания:
+
+- `error403.html.twig`
+- `error404.html.twig`
+- `error.html.twig` для остальных ошибок, включая `5xx`
+
+Важно: одного `cache:clear` в `prod` для проверки недостаточно.
+Чтобы увидеть кастомные страницы ошибок в браузере, само HTTP-приложение тоже должно реально работать с `APP_ENV=prod`.

--- a/practice/lesson-03/docker-compose.yml
+++ b/practice/lesson-03/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 volumes:
   postgres: ~
 services:
@@ -11,8 +10,6 @@ services:
       - ./docker/hosts/symfony:/etc/nginx/symfony
     ports:
       - "${NGINX_PORT}:80"
-    links:
-      - php
   postgres:
     image: postgres:alpine
     volumes:
@@ -29,8 +26,6 @@ services:
       - ${HOME}/.composer:/.composer
     environment:
       - COMPOSER_ALLOW_SUPERUSER=1
-    links:
-      - postgres
   node:
     image: node:alpine
     environment:

--- a/practice/lesson-03/webpack.config.js
+++ b/practice/lesson-03/webpack.config.js
@@ -25,9 +25,6 @@ Encore
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     .splitEntryChunks()
 
-    // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
-    .enableStimulusBridge('./assets/controllers.json')
-
     // will require an extra script tag for runtime.js
     // but, you probably want this, unless you're building a single-page app
     .enableSingleRuntimeChunk()
@@ -52,7 +49,7 @@ Encore
     // enables and configure @babel/preset-env polyfills
     .configureBabelPresetEnv((config) => {
         config.useBuiltIns = 'usage';
-        config.corejs = '3.23';
+        config.corejs = '3.38';
     })
 
     // enables Sass/SCSS support


### PR DESCRIPTION
Актуализированы материалы третьего практического задания по фронтенду в Symfony.

Что изменено:
- обновлены команды под `docker compose`;
- уточнён сценарий перехода на Webpack Encore в проектах, где уже может быть включён `AssetMapper`/`importmap`;
- скорректирован минимальный ориентир по `package.json` для задания;
- упрощён пример `webpack.config.js` до базового рабочего варианта без лишних зависимостей;
- из примера `docker-compose.yml` убраны устаревшие `links`;
- добавлены краткие замечания по очистке от `AssetMapper`, Bootstrap form theme и проверке кастомных страниц ошибок в `prod`.

Цель изменений:
сделать материалы актуальнее для современных Symfony-проектов, при этом сохранить исследовательский формат задания без чрезмерно подробной пошаговой инструкции.