### PR TITLE
Update lesson 05 docs for current Symfony billing API workflow

### DIFF
--- a/practice/lesson-05/README.md
+++ b/practice/lesson-05/README.md
@@ -3,24 +3,23 @@
 ## Установка бандлов 
 
 ```bash
-docker-compose exec php composer require doctrine maker-bundle symfony/security-bundle doctrine/doctrine-fixtures-bundle
+docker compose exec php composer require symfony/security-bundle
+docker compose exec php composer require --dev doctrine/doctrine-fixtures-bundle symfony/maker-bundle
 ```
 
 ## Генерация пользователя
 
 ```bash
-docker-compose exec php bin/console make:user
+docker compose exec php php bin/console make:user
 ```
 
 В качестве уникального идентификатора выберите email
 
-Укажите в аннотациях модели пользователя кастомное название таблицы (user - ключевое слово в postgres, с ним возникают проблемы при выполнении запросов):
+Укажите в entity пользователя кастомное название таблицы (user - ключевое слово в postgres, с ним возникают проблемы при выполнении запросов):
 
 ```php
-/**
- * @ORM\Entity(repositoryClass="App\Repository\UserRepository")
- * @ORM\Table(name="billing_user")
- */
+#[ORM\Entity(repositoryClass: UserRepository::class)]
+#[ORM\Table(name: 'billing_user')]
 ```
 
 ## Настройка JWT
@@ -28,10 +27,10 @@ docker-compose exec php bin/console make:user
 Установите бандл
 
 ```bash
-docker-compose exec php composer require lexik/jwt-authentication-bundle
+docker compose exec php composer require lexik/jwt-authentication-bundle
 ```
 
-Сгенерируйте ssh-ключи 
+Сгенерируйте RSA-ключи для подписи JWT
 
 ```bash
 mkdir -p config/jwt 
@@ -39,7 +38,7 @@ openssl genrsa -out config/jwt/private.pem -aes256 4096
 openssl rsa -pubout -in config/jwt/private.pem -out config/jwt/public.pem
 ```
 
-Убедитесь, что в .env стоит верное значение private key/passphrase
+Перенесите JWT-параметры в `.env.local` и `.env.test.local`. В `JWT_PASSPHRASE` укажите passphrase, который вы задали при генерации ключа.
 ```yaml
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
@@ -51,7 +50,7 @@ JWT_PASSPHRASE=your-passphrase
 ## Установка бандлов для регистрации
 
 ```bash
-docker-compose exec php composer require jms/serializer-bundle symfony/validator
+docker compose exec php composer require jms/serializer-bundle symfony/validator
 ```
 
 До реализации основного функционала создания пользователей, можно добавить нескольких с помощью фикстур. Можно использовать UserPasswordHasherInterface
@@ -70,7 +69,7 @@ $hasher = static::$container->get('security.user_password_hasher');
 ```
 
 ## DTO
-В структуру класса DTO входят переменные $username и $password.
+Для регистрации удобно использовать отдельный DTO-класс с полями `$email` и `$password`.
 
 Для валидации полей нужно использовать:
 
@@ -79,33 +78,36 @@ namespace App\Dto;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-class UserDto
+final class RegisterUserDto
 {
-    /**
-     * @Assert\NotBlank(message="Name is mandatory")
-     * @Assert\Email( message="Invalid email address" )
-     */
-    public string $username;
-    //...
+    #[Assert\NotBlank(message: 'Email should not be blank.')]
+    #[Assert\Email(message: 'Invalid email address.')]
+    public string $email;
+
+    #[Assert\NotBlank(message: 'Password should not be blank.')]
+    #[Assert\Length(min: 6, minMessage: 'Password should be at least {{ limit }} characters long.')]
+    public string $password;
 }
 ```
 
 Разбор и валидация запроса в экшне контроллера упрощенно должны выглядеть следующим образом:
 
-```bash
-$serializer = SerializerBuilder::create()->build();
-$userDto = $serializer->deserialize($request->getContent(), UserDto::class, 'json');
+```php
+/** @var RegisterUserDto $userDto */
+$userDto = $serializer->deserialize($request->getContent(), RegisterUserDto::class, 'json');
 $errors = $validator->validate($userDto);
 ```
 
-Для создания объекта сущности из DTO нужно создать соответствующую статическую функцию, которая будет формировать новый объект сущности из DTO-объекта:
+Отдельная статическая `fromDto()` не обязательна: можно собрать `User` прямо в контроллере или в отдельном сервисе.
 
-```bash
-$user = \App\Entity\User::fromDto($userDto);
+```php
+$user = new \App\Entity\User();
+$user->setEmail($userDto->email);
+// ...
 ```
 
 ## Получение текущего пользователя
-Чтобы получить текущего пользователя нужно получить токен и ваш публичный ключ. После чего нужно проверить токен и декодировать его, с помощью функции:
+Чтобы получить текущего пользователя в billing API, достаточно настроить `jwt` firewall и использовать `$this->getUser()`. Если нужно декодировать текущий токен вручную, можно использовать:
 ```php
   $decodedJwt = $this->jwtManager->decode($this->tokenStorageInterface->getToken());
 ```
@@ -126,19 +128,22 @@ curl -X POST -H "Content-Type: application/json" http://billing.study-on.local:8
 
 Установите необходимые бандлы и сконфигурируйте nelmio_api_doc.yaml
 ```bash
-docker-compose exec php composer require nelmio/api-doc-bundle twig asset
+docker compose exec php composer require nelmio/api-doc-bundle twig asset zircote/swagger-php
 ```
-Кнопка Authorize сохраняет токен. Для дальнейшего его использования в методе получения пользователя нужно добавить данную анотацию.
+Кнопка `Authorize` сохраняет токен. Для методов, требующих JWT, добавьте описание Bearer security scheme в `nelmio_api_doc.yaml` и укажите security requirement у защищённых endpoint'ов.
 
-```bash
-@Security(name="Bearer")
+```php
+#[OA\Get(
+    // ...
+    security: [['Bearer' => []]],
+)]
 ```
 
 ## Тестирование 
 
 Установите необходимые бандлы
 ```bash
-docker-compose exec php composer require symfony/dom-crawler symfony/browser-kit --dev
+docker compose exec php composer require --dev phpunit/phpunit symfony/browser-kit symfony/css-selector dama/doctrine-test-bundle
 ```
 
 ## Передача заголовка авторизации в тестах
@@ -147,7 +152,7 @@ docker-compose exec php composer require symfony/dom-crawler symfony/browser-kit
 
 ```php
 <?php
-namespace App\Tests;
+namespace App\Tests\Functional;
 
 class BillingUserControllerTest extends WebTestCase
 {
@@ -160,4 +165,3 @@ class BillingUserControllerTest extends WebTestCase
     
  }
 ```
-


### PR DESCRIPTION
Обновлены материалы lesson-05 под актуальный workflow проекта study-on.billing.

Что исправлено:

- команды переведены с docker-compose на docker compose;
- примеры bin/console приведены к рабочему виду;
- описание User обновлено под PHP attributes вместо старых Doctrine-аннотаций;
- уточнена настройка JWT-ключей и переменных окружения;
- раздел DTO и валидации приведён в соответствие с текущей реализацией регистрации через email/password;
- обновлён раздел по документации API с учётом nelmio/api-doc-bundle и zircote/swagger-php;
- обновлён раздел по тестированию с актуальным набором dev-зависимостей.

Изменения синхронизированы с реально работающей реализацией в study-on.billing, чтобы инструкции из урока соответствовали текущему стеку Symfony 8 и фактическим командам проекта.